### PR TITLE
Feat/mise improvements

### DIFF
--- a/dot_config/mise/conf.d/plugins.toml
+++ b/dot_config/mise/conf.d/plugins.toml
@@ -1,0 +1,2 @@
+[plugins]
+# specify a custom repo url

--- a/dot_config/mise/conf.d/settings.toml
+++ b/dot_config/mise/conf.d/settings.toml
@@ -1,35 +1,3 @@
-[tools]
-# global tool versions go here
-# Tools
-neovim = 'latest'
-bat = 'latest'
-dprint = 'latest'
-eza = 'latest'
-fd = 'latest'
-fzf = 'latest'
-fx = 'latest'
-gojq = 'latest'
-jqp = 'latest'
-ripgrep = 'latest'
-
-# Languages
-node = 'latest'
-go = 'latest'
-go-jsonnet = 'latest'
-jsonnet-bundler = 'latest'
-python = ['latest', '2']
-
-# Kubernetes
-kubectl = 'latest'
-k9s = 'latest'
-kubie = 'latest'
-krew = 'latest'
-helm = 'latest'
-tanka = 'latest'
-
-[plugins]
-# specify a custom repo url
-
 [settings]
 # plugins can read the versions files used by other version managers (if enabled by the plugin)
 # for example, .nvmrc in the case of node's nvm
@@ -43,11 +11,6 @@ always_keep_install = false         # deleted on failure by default
 # this is updated whenever a new runtime is installed
 # (note: this isn't currently implemented but there are plans to add it: https://github.com/jdx/mise/issues/128)
 plugin_autoupdate_last_check_duration = '10080' # set to 0 to disable updates, 1 week in minutes
-
-# config files with these prefixes will be trusted by default
-trusted_config_paths = [
-	{{ osClean .personal_project_folder | quote }},
-]
 
 verbose = false     # set to true to see full installation output, see `MISE_VERBOSE`
 asdf_compat = true  # set to true to ensure .tool-versions will be compatible with asdf, see `MISE_ASDF_COMPAT`

--- a/dot_config/mise/conf.d/tools.toml
+++ b/dot_config/mise/conf.d/tools.toml
@@ -1,0 +1,28 @@
+[tools]
+# global tool versions go here
+# Tools
+neovim = 'latest'
+bat = 'latest'
+dprint = 'latest'
+eza = 'latest'
+fd = 'latest'
+fzf = 'latest'
+fx = 'latest'
+gojq = 'latest'
+jqp = 'latest'
+ripgrep = 'latest'
+
+# Languages
+node = 'latest'
+go = 'latest'
+go-jsonnet = 'latest'
+jsonnet-bundler = 'latest'
+python = ['latest', '2']
+
+# Kubernetes
+kubectl = 'latest'
+k9s = 'latest'
+kubie = 'latest'
+krew = 'latest'
+helm = 'latest'
+tanka = 'latest'

--- a/dot_config/mise/conf.d/trusted-paths.toml.tmpl
+++ b/dot_config/mise/conf.d/trusted-paths.toml.tmpl
@@ -1,0 +1,5 @@
+# config files with these prefixes will be trusted by default
+[settings]
+trusted_config_paths = [
+	{{ osClean .personal_project_folder | quote }},
+]

--- a/dot_config/mise/conf.d/trusted-paths.toml.tmpl
+++ b/dot_config/mise/conf.d/trusted-paths.toml.tmpl
@@ -2,4 +2,5 @@
 [settings]
 trusted_config_paths = [
 	{{ osClean .personal_project_folder | quote }},
+	{{ if not (empty (get . "work_project_folder")) }}{{ osClean .work_project_folder | quote }},{{ end }}
 ]

--- a/dot_config/mise/create_config.toml
+++ b/dot_config/mise/create_config.toml
@@ -1,1 +1,5 @@
-# Default global config file.
+# Default global config file that gets changed when running things like:
+# mise use -g java@24
+# For that reason, we only create this file instead of fully managing it with chezmoi
+# as updates were causing diffs every time we needed to run `chezmoi apply`
+# Default files for mise are now all under `conf.d` and imported automatically.

--- a/dot_config/mise/create_config.toml
+++ b/dot_config/mise/create_config.toml
@@ -1,0 +1,1 @@
+# Default global config file.


### PR DESCRIPTION
Pop out mise default configs to conf.d dir to avoid conflicts when setting new global tools as `~/.config/mise/config.toml` changes in that case, causing issues when doing a `chezmoi apply` as we potentially overwrite it.

Now no diffs are created as the files under `~/.config/mise/conf.d` are never changed but are automatically imported by mise nonetheless.